### PR TITLE
Servercore 20 h2

### DIFF
--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -1,7 +1,7 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-FROM mcr.microsoft.com/windows/servercore:20H2
+FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
 
 #FROM --platform=linux/amd64 curlimages/curl as bins
 ARG containernetworkingCniVersion="1.1.1"

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -1,12 +1,12 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-ARG BASE="mcr.microsoft.com/windows/nanoserver:1809"
+FROM mcr.microsoft.com/windows/servercore:20H2
 
-FROM --platform=linux/amd64 curlimages/curl as bins
-ARG containernetworkingCniVersion="0.8.7"
-ARG cniVersion="0.2.0"
-ARG flannelVersion="v0.13.0"
+#FROM --platform=linux/amd64 curlimages/curl as bins
+ARG containernetworkingCniVersion="1.1.1"
+ARG cniVersion="0.3.0"
+ARG flannelVersion="v0.18.1"
 
 # Todo simplify this
 # We need both sets of binaries 
@@ -14,23 +14,23 @@ ARG flannelVersion="v0.13.0"
 # flannel.exe and hostlocal.exe from containernetworking 
 # flannel.exe recently moved to https://github.com/flannel-io/cni-plugin but has no releases
 WORKDIR /cni
-RUN curl -Lo cni.tgz https://github.com/containernetworking/plugins/releases/download/v${containernetworkingCniVersion}/cni-plugins-windows-amd64-v${containernetworkingCniVersion}.tgz
+RUN curl -Lo cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-windows-amd64-v1.1.1.tgz
 RUN tar -xf cni.tgz
-RUN rm cni.tgz
+RUN del cni.tgz
 
-RUN curl -Lo cni.zip https://github.com/microsoft/windows-container-networking/releases/download/v${cniVersion}/windows-container-networking-cni-amd64-v${cniVersion}.zip
-RUN unzip /cni/cni.zip
+RUN curl -Lo cni.zip https://github.com/microsoft/windows-container-networking/releases/download/v0.3.0/windows-container-networking-cni-amd64-v0.3.0.zip
+RUN tar -xf /cni/cni.zip
 
 WORKDIR /flannel 
-RUN curl -Lo flanneld.exe https://github.com/coreos/flannel/releases/download/${flannelVersion}/flanneld.exe
+RUN curl -Lo flanneld.exe https://github.com/coreos/flannel/releases/download/v0.18.1/flanneld.exe
 
-FROM $BASE
+#FROM $BASE
 
-ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+#ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
 
 ADD https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1 /flannel/hns.psm1
 COPY start.ps1 /flannel/start.ps1
-COPY --from=bins /cni /cni
-COPY --from=bins /flannel/flanneld.exe /flannel/flanneld.exe
+#COPY --from=bins /cni /cni
+#COPY --from=bins /flannel/flanneld.exe /flannel/flanneld.exe
 
 ENTRYPOINT ["PowerShell", "/c", "$env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/start.ps1"]

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -22,7 +22,8 @@ RUN curl -Lo cni.zip https://github.com/microsoft/windows-container-networking/r
 RUN tar -xf /cni/cni.zip
 
 WORKDIR /flannel 
-RUN curl -Lo flanneld.exe https://github.com/coreos/flannel/releases/download/v0.18.1/flanneld.exe
+RUN curl -Lo flannel-windows.tgz https://github.com/flannel-io/cni-plugin/releases/download/v1.1.0/cni-plugin-flannel-windows-amd64-v1.1.0.tgz
+RUN tar -xf flannel-windows.tgz
 
 #FROM $BASE
 
@@ -30,7 +31,7 @@ RUN curl -Lo flanneld.exe https://github.com/coreos/flannel/releases/download/v0
 
 ADD https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1 /flannel/hns.psm1
 COPY start.ps1 /flannel/start.ps1
-#COPY --from=bins /cni /cni
-#COPY --from=bins /flannel/flanneld.exe /flannel/flanneld.exe
+# COPY --from=bins /cni /cni
+# COPY --from=bins /flannel/flanneld.exe /flannel/flanneld.exe
 
 ENTRYPOINT ["PowerShell", "/c", "$env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/start.ps1"]

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -27,7 +27,7 @@ RUN tar -xf flannel-windows.tgz
 
 #FROM $BASE
 
-#ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
+ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
 
 ADD https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1 /flannel/hns.psm1
 COPY start.ps1 /flannel/start.ps1

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -22,8 +22,8 @@ RUN curl -Lo cni.zip https://github.com/microsoft/windows-container-networking/r
 RUN tar -xf /cni/cni.zip
 
 WORKDIR /flannel 
-RUN curl -Lo flannel-windows.tgz https://github.com/flannel-io/cni-plugin/releases/download/v1.1.0/cni-plugin-flannel-windows-amd64-v1.1.0.tgz
-RUN tar -xf flannel-windows.tgz
+RUN curl -Lo flannel.exe https://github.com/flannel-io/cni-plugin/releases/download/v1.0/flannel.exe
+
 
 #FROM $BASE
 

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -23,7 +23,8 @@ RUN tar -xf /cni/cni.zip
 
 WORKDIR /flannel 
 RUN curl -Lo flannel.exe https://github.com/flannel-io/cni-plugin/releases/download/v1.0/flannel.exe
-
+RUN curl -Lo windows-amd64.tar.gz https://github.com/flannel-io/flannel/releases/download/v0.19.0/flannel-v0.19.0-windows-amd64.tar.gz
+RUN tar -xf /flannel/windows-amd64.tar.gz
 
 #FROM $BASE
 

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -1,7 +1,7 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-FROM mcr.microsoft.com/powershell:nanoserver-ltsc2022
+FROM mcr.microsoft.com/windows/servercore:20H2
 
 #FROM --platform=linux/amd64 curlimages/curl as bins
 ARG containernetworkingCniVersion="1.1.1"

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -14,7 +14,7 @@ ARG flannelVersion="v0.18.1"
 # flannel.exe and hostlocal.exe from containernetworking 
 # flannel.exe recently moved to https://github.com/flannel-io/cni-plugin but has no releases
 WORKDIR /cni
-RUN curl -Lo cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.1.1/cni-plugins-windows-amd64-v1.1.1.tgz
+RUN curl -Lo cni.tgz https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-windows-amd64-v1.0.0.tgz
 RUN tar -xf cni.tgz
 RUN del cni.tgz
 

--- a/hostprocess/flannel/flanneld/Dockerfile
+++ b/hostprocess/flannel/flanneld/Dockerfile
@@ -4,9 +4,9 @@
 FROM mcr.microsoft.com/windows/servercore:20H2
 
 #FROM --platform=linux/amd64 curlimages/curl as bins
-ARG containernetworkingCniVersion="1.1.1"
-ARG cniVersion="0.3.0"
-ARG flannelVersion="v0.18.1"
+# ARG containernetworkingCniVersion="1.1.1"
+# ARG cniVersion="0.3.0"
+# ARG flannelVersion="v0.18.1"
 
 # Todo simplify this
 # We need both sets of binaries 

--- a/hostprocess/flannel/flanneld/flannel-bridge.yaml
+++ b/hostprocess/flannel/flanneld/flannel-bridge.yaml
@@ -1,0 +1,139 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-windows-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf-containerd.json: |
+    {
+      "cniVersion": "0.2.0",
+      "name": "cbr0",
+      "type": "flannel",
+      "capabilities": {
+        "portMappings": true,
+        "dns": true
+      },
+      "delegate": {
+        "type": "sdnbridge",
+        "optionalFlags" : {
+          "forceBridgeGateway" : true
+        },
+        "AdditionalArgs": [
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "OutBoundNAT",
+              "Settings": {
+                "Exceptions": []
+              }
+            }
+          },
+          {
+            "Name": "EndpointPolicy",
+            "Value": {
+              "Type": "SDNROUTE",
+              "Settings": {
+                "DestinationPrefix": "",
+                "NeedEncap": true
+              }
+            }
+          },
+          {
+            "Name":"EndpointPolicy",
+            "Value":{
+              "Type":"ProviderAddress",
+                "Settings":{
+                    "ProviderAddress":""
+              }
+            }
+          }
+        ]
+      }
+    }
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds-windows-amd64
+  labels:
+    tier: node
+    app: flannel
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: flannel
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - windows
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      serviceAccountName: flannel
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+        # Mark the pod as a critical add-on for rescheduling.
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      containers:
+      - name: kube-flannel
+        image: sigwindowstools/flannel:v0.14.0-hostprocess
+        imagePullPolicy: Always
+        volumeMounts:
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+        - name: flannel-windows-cfg
+          mountPath: /etc/kube-flannel-windows/
+        - name: kubeadm-config
+          mountPath: /etc/kubeadm-config/
+        - name: kube-proxy
+          mountPath: /flannel-config-file
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+      volumes:
+      - name: kube-proxy
+        configMap:
+          name: kube-proxy
+      - name: flannel-cfg
+        configMap:
+          name: kube-flannel-cfg
+      - name: flannel-windows-cfg
+        configMap:
+          name: kube-flannel-windows-cfg
+      - name: kubeadm-config
+        configMap:
+          name: kubeadm-config

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -17,7 +17,7 @@ Write-Host "update cni config"
 $cniJson = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kube-flannel-windows/cni-conf-containerd.json | ConvertFrom-Json
 $serviceSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("serviceSubnet:")) {$_.Trim().Split()[1]}}
 $podSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("podSubnet:")) {$_.Trim().Split()[1]}}
-$na = Get-NetRoute | Where { $_.DestinationPrefix -eq '0.0.0.0/0' } | Select-Object -Property ifIndex
+
 $managementIP = (Get-NetIPAddress -ifIndex $na[0].ifIndex -AddressFamily IPv4).IPAddress
 
 #set info and save
@@ -40,4 +40,4 @@ write-host $env:POD_NAME
 write-host $env:POD_NAMESPACE
 
 Write-Host "Starting flannel"
-& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flannel.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP
+& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flanneld.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -40,4 +40,4 @@ write-host $env:POD_NAME
 write-host $env:POD_NAMESPACE
 
 Write-Host "Starting flannel"
-& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flannel-amd64.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP
+& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flannel.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -3,6 +3,7 @@ $ErrorActionPreference = "Stop";
 # flannel uses host-local, flannel.exe, and sdnoverlay so copy that to the correct location
 Write-Output "Copying SDN CNI binaries to host"
 Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/cni/*" -Destination "c:\opt\cni\bin" -Force
+Copy-Item -Path "$env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/*" -Destination "c:\opt\cni\bin" -Force
 
 Write-Host "copy flannel config"
 mkdir -force C:\etc\kube-flannel\

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -18,6 +18,7 @@ $cniJson = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kube-flannel-windo
 $serviceSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("serviceSubnet:")) {$_.Trim().Split()[1]}}
 $podSubnet = get-content $env:CONTAINER_SANDBOX_MOUNT_POINT/etc/kubeadm-config/ClusterConfiguration | ForEach-Object -Process {if($_.Contains("podSubnet:")) {$_.Trim().Split()[1]}}
 
+$na = Get-NetRoute | Where { $_.DestinationPrefix -eq '0.0.0.0/0' } | Select-Object -Property ifIndex
 $managementIP = (Get-NetIPAddress -ifIndex $na[0].ifIndex -AddressFamily IPv4).IPAddress
 
 #set info and save

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -30,6 +30,7 @@ Set-Content -Path c:/etc/cni/net.d/10-flannel.conf ($cniJson | ConvertTo-Json -d
 # set route for metadata servers in clouds
 # https://github.com/kubernetes-sigs/sig-windows-tools/issues/36
 Write-Host "add route"
+route DELETE 169.254.169.254
 route /p add 169.254.169.254 mask 255.255.255.255 0.0.0.0
 
 write-host "copy sa info (should be able to do this with a change to go client"

--- a/hostprocess/flannel/flanneld/start.ps1
+++ b/hostprocess/flannel/flanneld/start.ps1
@@ -40,4 +40,4 @@ write-host $env:POD_NAME
 write-host $env:POD_NAMESPACE
 
 Write-Host "Starting flannel"
-& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flanneld.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP
+& $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel/flannel-amd64.exe --kube-subnet-mgr --kubeconfig-file $env:CONTAINER_SANDBOX_MOUNT_POINT/flannel-config-file/kubeconfig.conf --iface $managementIP

--- a/hostprocess/flannel/kube-proxy/Dockerfile
+++ b/hostprocess/flannel/kube-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-ARG BASE="mcr.microsoft.com/windows/servercore:20H2"
+ARG BASE="mcr.microsoft.com/powershell:nanoserver-ltsc2022"
 
 # FROM --platform=linux/amd64 curlimages/curl as bins
 FROM $BASE

--- a/hostprocess/flannel/kube-proxy/Dockerfile
+++ b/hostprocess/flannel/kube-proxy/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /kube-proxy
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/windows/amd64/kube-proxy.exe
 RUN curl -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
 
-FROM $BASE
+
 
 ENV PATH="C:\Windows\system32;C:\Windows;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;"
 
 ADD start.ps1 /kube-proxy/start.ps1
-COPY --from=bins /kube-proxy /kube-proxy
+# COPY --from=bins /kube-proxy /kube-proxy
 
 ENTRYPOINT ["PowerShell", "/c", "$env:CONTAINER_SANDBOX_MOUNT_POINT/kube-proxy/start.ps1"]

--- a/hostprocess/flannel/kube-proxy/Dockerfile
+++ b/hostprocess/flannel/kube-proxy/Dockerfile
@@ -1,7 +1,7 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-ARG BASE="mcr.microsoft.com/powershell:nanoserver-ltsc2022"
+ARG BASE="mcr.microsoft.com/windows/servercore:20H2"
 
 # FROM --platform=linux/amd64 curlimages/curl as bins
 FROM $BASE

--- a/hostprocess/flannel/kube-proxy/Dockerfile
+++ b/hostprocess/flannel/kube-proxy/Dockerfile
@@ -1,13 +1,13 @@
 # Note this image doesn't really mater for hostprocess
 # the files in the image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host
 # but the file system is the Host NOT the container
-ARG BASE="mcr.microsoft.com/windows/nanoserver:1809"
+ARG BASE="mcr.microsoft.com/windows/servercore:20H2"
 
-FROM --platform=linux/amd64 curlimages/curl as bins
-ARG k8sVersion="v1.22.0"
+# FROM --platform=linux/amd64 curlimages/curl as bins
+FROM $BASE
 
 WORKDIR /kube-proxy
-RUN curl -LO https://dl.k8s.io/$k8sVersion/bin/windows/amd64/kube-proxy.exe
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.24.0/bin/windows/amd64/kube-proxy.exe
 RUN curl -LO https://raw.githubusercontent.com/microsoft/SDN/master/Kubernetes/windows/hns.psm1
 
 FROM $BASE

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -67,7 +67,7 @@ $env:Path += ";$global:KubernetesPath"
 
 DownloadFile $kubeletBinPath https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubelet.exe
 DownloadFile "$global:KubernetesPath\kubeadm.exe" https://dl.k8s.io/$KubernetesVersion/bin/windows/amd64/kubeadm.exe
-DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.0.4/wins.exe
+DownloadFile "$global:KubernetesPath\wins.exe" https://github.com/rancher/wins/releases/download/v0.4.4/wins.exe
 
 if ($ContainerRuntime -eq "Docker") {
     # Create host network to allow kubelet to schedule hostNetwork pods

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -104,7 +104,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --log-dir=/var/log/kubelet--enforce-node-allocatable=`"`" --cgroups-per-qos=false --logtostderr=false"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --log-dir=/var/log/kubelet --enforce-node-allocatable=`"`" --cgroups-per-qos=false --logtostderr=false"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -104,7 +104,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --pod-infra-container-image=`"mcr.microsoft.com/oss/kubernetes/pause:3.6`" --enable-debugging-handlers --cgroups-per-qos=false --enforce-node-allocatable=`"`" --network-plugin=cni --resolv-conf=`"`" --log-dir=/var/log/kubelet --logtostderr=false --image-pull-progress-deadline=20m"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --log-dir=/var/log/kubelet --logtostderr=false"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""

--- a/kubeadm/scripts/PrepareNode.ps1
+++ b/kubeadm/scripts/PrepareNode.ps1
@@ -104,7 +104,7 @@ if ($global:containerRuntime -eq "Docker") {
     }
 }
 
-$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --log-dir=/var/log/kubelet --logtostderr=false"
+$cmd = "C:\k\kubelet.exe $global:KubeletArgs --cert-dir=$env:SYSTEMDRIVE\var\lib\kubelet\pki --config=/var/lib/kubelet/config.yaml --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --hostname-override=$(hostname) --log-dir=/var/log/kubelet--enforce-node-allocatable=`"`" --cgroups-per-qos=false --logtostderr=false"
 
 Invoke-Expression $cmd'
 $StartKubeletFileContent = $StartKubeletFileContent -replace "{{CONTAINER_RUNTIME}}", "`"$ContainerRuntime`""


### PR DESCRIPTION
This PR has the following fixes:
- It changes the Windows base image to `servercore:20H2`
- It copies the flannel binaries into the correct location on the host
- It copies the the plugin files into the `flannel` directory
- Adds a new deployment file for flannel for `sdnbridge`
- delete the metadata server route before adding it


